### PR TITLE
[PFG5-131] Fix in category filter styles and token expiration

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -174,6 +174,7 @@ body{
             display: flex;
             flex-flow: row wrap;
             justify-content: center;
+            align-items: center;
             list-style: none;
             gap: 10px;
             li{ 
@@ -182,7 +183,7 @@ body{
                     border-radius: 10px;
                     color: $brown;
                     padding: 7px 15px;
-                    background-color: rgba(255, 255, 255, 0.5);
+                    background-color: rgba(255, 255, 255, 0.555);
                 }
             }
         }

--- a/src/components/CategoriesHome.jsx
+++ b/src/components/CategoriesHome.jsx
@@ -46,11 +46,11 @@ const CategoriesHome = ({ selectedCategories, setSelectedCategories, fetchExperi
             key={category.id}
             style={{
               backgroundColor: categoryColors[category.id] ? categoryColors[category.id] : '#000',
-              border: selectedCategories.includes(category.id) ? '2px solid brown' : 'none',
+              border: selectedCategories.includes(category.id) ? '2.5px solid #562210' : 'none',
+              boxShadow: categoryColors[category.id]? '0px 2px 0px 0px #562210' : 'none',
               cursor: 'pointer',
             }}
             onClick={() => handleCategoryClick(category.id)}
-            className={selectedCategories.includes(category.id) ? 'selected' : ''}
           >
             <p>{category.name}</p>
           </li>

--- a/src/components/Message/Message.jsx
+++ b/src/components/Message/Message.jsx
@@ -1,0 +1,16 @@
+import styles from './message.module.scss'
+import capiSearch from '../../../public/capi_sunglasses_top.svg'
+const Message = () => {
+  return (
+    <div className={styles.container_message}>
+      <img src={capiSearch} alt="" className={styles.imgCapi}/>
+      <div>
+      <h3>Ups! I couldn't find any experience related to these categories</h3>
+      <p>Try with others</p>
+      </div>
+
+    </div>
+  )
+}
+
+export default Message

--- a/src/components/Message/message.module.scss
+++ b/src/components/Message/message.module.scss
@@ -1,0 +1,17 @@
+@use "../../variables" as *;
+
+.container_message {
+margin-top: 3rem;
+display: flex;
+align-items: center;
+gap: 15px;
+
+  @media (min-width: 1000px) {
+    width: 500px;
+  }
+}
+
+.imgCapi{
+    transform: rotate(180deg); 
+    width: 100px;
+}

--- a/src/components/Pagination/ExperiencesList.jsx
+++ b/src/components/Pagination/ExperiencesList.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import ProductCard from "../Cards/ProductCard";
 import Pagination from './Pagination';
+import Message from "../Message/Message";
 
 export const ExperiencesList = ({ experiences }) => {
   const [shuffledExperiences, setShuffledExperiences] = useState([]);
@@ -36,7 +37,7 @@ export const ExperiencesList = ({ experiences }) => {
                 </div>
               ))
           ) : (
-            <p>No experiences found for the selected categories.</p>
+           <Message/>
           )}
         </div>
       </div>

--- a/src/hooks/useAuthLogin.jsx
+++ b/src/hooks/useAuthLogin.jsx
@@ -31,8 +31,11 @@ const useAuthLogin = () =>{
     const checkToken = () => {
         const token = localStorage.getItem("token");
         if (token) {
+            if(isTokenExpired(token)){
+                 localStorage.removeItem('token');
+                 return
+            }
             const decodedToken = decodeJwt(token);
-            console.log(decodedToken);
             setRole(decodedToken.role);
             setUsername(decodedToken.sub);
         }


### PR DESCRIPTION
* Se arreglo el estilo de las categorías y se creo un componente para el mensaje al no encontrar experiencias con las categorías seleccionadas.
![image](https://github.com/user-attachments/assets/ea7164bd-40e9-4204-b865-0983c260e4c3)

* Y ahora cuando se vence el token, se cierra la sesión y sale nuevamente en el `Header `el boton de `create account ` y `login`