### PR TITLE
Added validation for edit Property

### DIFF
--- a/src/components/Buttons/PrimaryButton.jsx
+++ b/src/components/Buttons/PrimaryButton.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import style from './button.module.scss'
 
-const PrimaryButton = ({children, func, type = "button"}) => {
+const PrimaryButton = ({children, func, type = "button", disabled = ""}) => {
   return (
-    <button className={style.primaryButton} onClick={func} type={type}>{children}</button>
+    <button className={style.primaryButton} onClick={func} type={type} disabled={disabled}>{children}</button>
   )
 }
 

--- a/src/components/Buttons/button.module.scss
+++ b/src/components/Buttons/button.module.scss
@@ -11,6 +11,10 @@
     &:hover{
       background-color: $secundary-orange;
     }
+    &:disabled {
+      cursor: not-allowed; 
+      opacity: 0.5; 
+    }
 }
 
 .secundaryButton{
@@ -25,6 +29,10 @@
     &:hover {
         background-color: #a5dbd3aa;
       }
+    &:disabled {
+        cursor: not-allowed; 
+        opacity: 0.5; 
+    }
 }
 
 .closeButton {
@@ -36,10 +44,13 @@
     font-size: 20px;
     color: $brown;
     cursor: pointer;
-  
     &:hover {
       color: $secundary-orange;
     }
+    &:disabled {
+      cursor: not-allowed; 
+      opacity: 0.5; 
+  }
   }
 
 .ClearButton{
@@ -51,4 +62,8 @@
     height: 38px;
     font-weight: 400;
     background-color: rgba(255, 255, 255, 0);
+    &:disabled {
+      cursor: not-allowed; 
+      opacity: 0.5; 
+  }
 }

--- a/src/components/Properties/Properties.jsx
+++ b/src/components/Properties/Properties.jsx
@@ -12,6 +12,12 @@ const Properties = () => {
   const [newProperty, setNewProperty] = useState({ name: '', description: '', image: '' });
   const [idToEdit, setIdToEdit] = useState('');
   const [errors, setErrors] = useState({ name: '', description: '', image: '' });
+  const [isModified, setIsModified] = useState(false);
+
+  const handleFieldChange = (field, value) => {
+    setNewProperty((prev) => ({ ...prev, [field]: value }));
+    setIsModified(true); // Marca como modificado cuando cambia un campo
+  };
 
   const handleAddProperty = async() => {
     const error = await addProperty(newProperty);
@@ -82,6 +88,7 @@ const Properties = () => {
     const toEdit = await fetchPropertyByID(id);
     setNewProperty({ name: toEdit.name, description: toEdit.description, image: toEdit.image });
     setIdToEdit(id);
+    setIsModified(false);
   };
 
   const handleEditProperty = () => {
@@ -135,6 +142,7 @@ const Properties = () => {
   const cancelEdit = () => {
     setIdToEdit('');
     setNewProperty({ name: '', description: '', image: '' });
+    setIsModified(false);
   };
 
   const handleSubmit = (e) => {
@@ -165,6 +173,7 @@ const Properties = () => {
       ...prevProperty,
       image: base64Images[0],
     }));
+    setIsModified(true);
   };
   
   const handleRemoveImg = () => {
@@ -172,6 +181,7 @@ const Properties = () => {
       ...newProperty,
       image: '',
     })
+    setIsModified(true);
   }
 
 
@@ -189,7 +199,7 @@ const Properties = () => {
             placeholder="Enter a name"
             id='name'
             value={newProperty.name}
-            onChange={(e) => setNewProperty({ ...newProperty, name: e.target.value })}
+            onChange={(e) => handleFieldChange('name', e.target.value)}
             required
           />
           {errors.name && <p className="error">{errors.name}</p>}
@@ -202,7 +212,7 @@ const Properties = () => {
             placeholder="Enter a description"
             id='description'
             value={newProperty.description}
-            onChange={(e) => setNewProperty({ ...newProperty, description: e.target.value })}
+            onChange={(e) => handleFieldChange('description', e.target.value)}
             required
           />
           {errors.description && <p className="error">{errors.description}</p>}
@@ -241,11 +251,11 @@ const Properties = () => {
 
         {idToEdit ? 
           <div className='buttonsContainer'>
-            <PrimaryButton type='submit'>Save Property</PrimaryButton>
+            <PrimaryButton type='submit' disabled={!isModified}>Save Property</PrimaryButton>
             <PrimaryButton func={cancelEdit}>Cancel</PrimaryButton>
           </div>
           : 
-          <PrimaryButton type='submit'>Add Property</PrimaryButton>}
+          <PrimaryButton type='submit' disabled={!isModified}>Add Property</PrimaryButton>}
       </form>
 
       <div className='adminList'>


### PR DESCRIPTION
when all inputs are blank in add Properties, the add button is disabled:
![image](https://github.com/user-attachments/assets/bd9ad6f1-f57e-44e9-8132-d329e53f5ea1)

If detects any changes, the button is enabled:
![image](https://github.com/user-attachments/assets/427f4e6c-0803-487f-89aa-a14371be16bd)

In edit property, is the same:
If not detects any changes:
![image](https://github.com/user-attachments/assets/8999d730-9904-4f73-8991-d1e8aa6ae693)

If detects changes:
![image](https://github.com/user-attachments/assets/cb6a113d-3e6f-4ef6-8c48-e5aab9ff4fda)

If the user changes the property to edit, the button setts in disable mode.


ADDED NEW STYLES TO PRIMARY BUTTON.