### PR TITLE
Pfg5 169 fix/reservartion history

### DIFF
--- a/src/components/Categories/Categories.jsx
+++ b/src/components/Categories/Categories.jsx
@@ -100,6 +100,7 @@ const Categories = () => {
   };
 
   const enableEditMode = async (id) => {
+    setErrors({})
     const toEdit = await fetchCategoryByID(id);
     setNewCategory({name: toEdit.name, description: toEdit.description});
     setIdToEdit(id);
@@ -156,6 +157,7 @@ const Categories = () => {
   const cancelEdit = () => {
     setIdToEdit('');
     setNewCategory({ name: '', description: ''});
+    setErrors({})
   };
 
   const handleSubmit = (e) => {

--- a/src/components/Experiences/Experiences.jsx
+++ b/src/components/Experiences/Experiences.jsx
@@ -442,7 +442,7 @@ const Experiences = () => {
     if (isActive == false) {
       setIsActive(!isActive);
     }
-
+    setErrors({})
     scrollToDiv();
 
     const toEdit = await fetchExperienceByID(id);

--- a/src/components/Experiences/Experiences.jsx
+++ b/src/components/Experiences/Experiences.jsx
@@ -364,6 +364,7 @@ const Experiences = () => {
     setSelectedCategories([]);
     setSelectedProperties([]);
     setIsModified(false)
+    setErrors({})
   };
 
   const deleteError = (parameter) => {
@@ -493,12 +494,34 @@ const Experiences = () => {
     idToEditRef.current = idToEdit;
   }, [idToEdit]);
 
+  const cleanInputs = () => {
+    setIdToEdit('');
+    setNewExperience({
+    title: "",
+    country: "",
+    ubication: "",
+    description: "",
+    quantity: 0,
+    timeUnit: "",
+    images: [],
+    categoryIds: [],
+    propertyIds: [],
+    serviceHours: "",
+    availableDays:[]
+  }); 
+
+  setSelectedCategories([]);
+  setSelectedProperties([]);
+  setErrors({});
+  setIsModified(false);
+  }
+
   function ToggleButton() {
       if(isModifiedRef.current){
         Swal.fire({
           imageUrl: '/warningCapi.svg',
           imageWidth: 200,
-          title: "Exit without saving?",
+          title: "Continue without saving?",
           text: "Your changes will be discard",
           showCancelButton: true,
           confirmButtonText: "Yes",
@@ -510,25 +533,13 @@ const Experiences = () => {
           }
         }).then( (result) => {
             if (result.isConfirmed) {
-              setIdToEdit('');
-              setNewExperience({
-              title: "",
-              country: "",
-              ubication: "",
-              description: "",
-              quantity: 0,
-              timeUnit: "",
-              images: [],
-              categoryIds: [],
-              propertyIds: [],
-              serviceHours: "",
-              availableDays:[]
-            }); 
-            setSelectedCategories([])
-            setSelectedProperties([])
+             cleanInputs();
             }
           });
+        }else if(idToEditRef.current && !isModifiedRef.current){
+          cleanInputs()
         }else{
+          setErrors({});
           setIsActive(!isActive);
     }
 
@@ -542,7 +553,7 @@ const Experiences = () => {
       {loading ? <Loading /> : null}
       <div className={style.titleButtonExp}>
         <h3 ref={divRef}>List Experiences</h3>
-        <PrimaryButton func={ToggleButton}>Create Experience</PrimaryButton>
+        <PrimaryButton func={ToggleButton}>Create new experience</PrimaryButton>
       </div>
 
       <section className="content-general-experience">

--- a/src/components/Experiences/experiences.module.scss
+++ b/src/components/Experiences/experiences.module.scss
@@ -50,7 +50,7 @@
 
 .titleButtonExp{
   margin:  10px 30px;
-  width: 180px;
+  width: 190px;
   display: flex;
   flex-direction: column;
   gap: 5px;

--- a/src/components/Properties/Properties.jsx
+++ b/src/components/Properties/Properties.jsx
@@ -89,6 +89,7 @@ const Properties = () => {
     setNewProperty({ name: toEdit.name, description: toEdit.description, image: toEdit.image });
     setIdToEdit(id);
     setIsModified(false);
+    setErrors({});
   };
 
   const handleEditProperty = () => {
@@ -143,6 +144,7 @@ const Properties = () => {
     setIdToEdit('');
     setNewProperty({ name: '', description: '', image: '' });
     setIsModified(false);
+    setErrors({});
   };
 
   const handleSubmit = (e) => {


### PR DESCRIPTION
Fixed forms Experience, Categories and Properties errors, when we cancel creation or select edit other item, the orange imput errors disappear

